### PR TITLE
Refactor dataupload.py for improved readability

### DIFF
--- a/scripts/dataupload.py
+++ b/scripts/dataupload.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import sys, gzip, json, ipaddress, re, pathlib
-from typing import Dict, List, Any
 
 """
 Number of most significant bits used to partition the lookup db. Each partition is stored as one key/value pair in
@@ -25,12 +24,12 @@ def create_kv_ip_partitions(entries):
         start_ip = ipaddress.ip_address(entry["s"])
         start_ip_int = int(start_ip)
         partition_prefix_len = V4_PREFIX_LEN if start_ip.version == 4 else V6_PREFIX_LEN
-        mask = int('1'*partition_prefix_len, 2)
+        mask = int('1' * partition_prefix_len, 2)
 
         # part_start is the top n bits of the starting ip in this entry, right shifted to max
         part_start = (start_ip_int >> (start_ip.max_prefixlen - partition_prefix_len)) & mask
         end_ip = entry["e"] if start_ip.version == 4 else ipaddress.ip_address(v6_uncompress(entry["e"]))
-        part_end = (int(end_ip) >> (start_ip.max_prefixlen - partition_prefix_len)) & mask # partition end
+        part_end = (int(end_ip) >> (start_ip.max_prefixlen - partition_prefix_len)) & mask  # partition end
 
         # because start/end space may span boundary created by network_prefix_len, we need to make sure that
         # we're creating duplicate entries so that a lookup using network_prefix_len of an incoming request
@@ -38,7 +37,7 @@ def create_kv_ip_partitions(entries):
         # e.g. if start/end are 1.0.0.0 and 1.1.0.0.0, when network_prefix_len=16, an incoming request from an IP
         # 1.1.1.1 needs to be able to find the lookup key corresponding to it
         for i in range(0, 1 + part_end - part_start):
-            key = "m%d/v%d/%d" % (partition_prefix_len, start_ip.version, part_start+i)
+            key = "m%d/v%d/%d" % (partition_prefix_len, start_ip.version, part_start + i)
             if key not in partitions:
                 arr = []
                 partitions[key] = arr
@@ -46,8 +45,10 @@ def create_kv_ip_partitions(entries):
                 arr = partitions[key]
             arr.append(entry)
 
-    return sorted([{"key": k, "value": json.dumps(v, separators=(',', ':'))} for k, v in partitions.items()],
-                  key=lambda x: int(x["key"].split("/")[2]))
+    return sorted(
+        [{"key": k, "value": json.dumps(v, separators=(',', ':'))} for k, v in partitions.items()],
+        key=lambda x: int(x["key"].split("/")[2])
+    )
 
 
 """
@@ -57,25 +58,30 @@ def create_kv_asn_partitions(entries):
     partitions = {}
     for entry in entries:
         start_ip = str(ipaddress.ip_address(entry["s"]))
-        end_ip   = str(ipaddress.ip_address(entry["e"] if '.' in start_ip else v6_uncompress(entry["e"])))
-        asn      = entry["a"]
-        country  = entry["c"]
-        name     = entry["n"]
-        key      = "asn/v1/%d" % asn
+        end_ip = str(ipaddress.ip_address(entry["e"] if '.' in start_ip else v6_uncompress(entry["e"])))
+        asn = entry["a"]
+        country = entry["c"]
+        name = entry["n"]
+        key = "asn/v1/%d" % asn
 
         if key in partitions:
             asn_obj = partitions[key]
         else:
-            asn_obj = { "as": { "asn": asn, "country": country, "name": name }, "networks": [] }
+            asn_obj = {"as": {"asn": asn, "country": country, "name": name}, "networks": []}
             partitions[key] = asn_obj
 
         if asn_obj["as"]["name"] != name or asn_obj["as"]["country"] != country:
-            print("mismatching in AS %d %s: %s != %s; %s != %s" %
-                  (asn, start_ip, asn_obj["as"]["name"], name, asn_obj["as"]["country"], country), file=sys.stderr)
-        asn_obj["networks"].append({ "start": start_ip, "end": end_ip })
+            print(
+                "mismatching in AS %d %s: %s != %s; %s != %s" %
+                (asn, start_ip, asn_obj["as"]["name"], name, asn_obj["as"]["country"], country),
+                file=sys.stderr
+            )
+        asn_obj["networks"].append({"start": start_ip, "end": end_ip})
 
-    return sorted([{"key": k, "value": json.dumps(v, separators=(',', ':'))} for k, v in partitions.items()],
-                  key=lambda x: int(x["key"].split("/")[2]))
+    return sorted(
+        [{"key": k, "value": json.dumps(v, separators=(',', ':'))} for k, v in partitions.items()],
+        key=lambda x: int(x["key"].split("/")[2])
+    )
 
 
 """
@@ -102,20 +108,22 @@ def read_ip_db(tsv_file):
         for line in f.readlines():
             line = line.strip()
             arr = line.split('\t')
-            if len(arr) != 5: continue
+            if len(arr) != 5:
+                continue
             asn = int(arr[2])
-            if asn == 0: continue
+            if asn == 0:
+                continue
             country = arr[3]
             name = arr[4]
 
-            if ':' in arr[0]: # v6
+            if ':' in arr[0]:  # v6
                 start = arr[0]
                 end = v6_compress(arr[1])
-                entries.append({"s":start, "e":end, "a":asn, "c":country, "n":name})
-            else: # v4
+                entries.append({"s": start, "e": end, "a": asn, "c": country, "n": name})
+            else:  # v4
                 start = int(ipaddress.ip_address(arr[0]))
                 end = int(ipaddress.ip_address(arr[1]))
-                entries.append({"s":start, "e":end, "a":asn, "c":country, "n":name})
+                entries.append({"s": start, "e": end, "a": asn, "c": country, "n": name})
 
         return entries
 
@@ -131,7 +139,7 @@ def v6_compress(ip):
 Uncompresses an IPv6 address that may have been compressed
 """
 def v6_uncompress(ip):
-    return ip.replace('X', ':'.join(['ffff']*(8-ip.count(':'))))
+    return ip.replace('X', ':'.join(['ffff'] * (8 - ip.count(':'))))
 
 
 """
@@ -141,19 +149,32 @@ def test_ip_lookup(ip_addr, partitions):
     ip = ipaddress.ip_address(ip_addr)
     prefix_len = (V4_PREFIX_LEN if ip.version == 4 else V6_PREFIX_LEN)
     ip_int = int(ip)
-    key = "m%d/v%d/%d" % (prefix_len, ip.version, ip_int >> ((ip.max_prefixlen - prefix_len) & int('1'*prefix_len, 2)))
-    for part in partitions:
-        if part["key"] == key:
-            arr = json.loads(part["value"])
+    mask = int('1' * prefix_len, 2)
+    partition_id = (ip_int >> (ip.max_prefixlen - prefix_len)) & mask
+    key = "m%d/v%d/%d" % (prefix_len, ip.version, partition_id)
+
+    for partition in partitions:
+        if partition["key"] == key:
+            arr = json.loads(partition["value"])
             for e in arr:
                 if ip.version == 4:
                     if e["s"] <= ip_int <= e["e"]:
-                        return {"s":ipaddress.ip_address(e["s"]), "e":ipaddress.ip_address(e["e"]),
-                                "a":e["a"], "c":e["c"], "n":e["n"]}
+                        return {
+                            "s": ipaddress.ip_address(e["s"]),
+                            "e": ipaddress.ip_address(e["e"]),
+                            "a": e["a"],
+                            "c": e["c"],
+                            "n": e["n"],
+                        }
                 else:
                     if int(ipaddress.ip_address(e["s"])) <= ip_int <= int(ipaddress.ip_address(v6_uncompress(e["e"]))):
-                        return {"s":ipaddress.ip_address(e["s"]), "e":ipaddress.ip_address(v6_uncompress(e["e"])),
-                                "a":e["a"], "c":e["c"], "n":e["n"]}
+                        return {
+                            "s": ipaddress.ip_address(e["s"]),
+                            "e": ipaddress.ip_address(v6_uncompress(e["e"])),
+                            "a": e["a"],
+                            "c": e["c"],
+                            "n": e["n"],
+                        }
 
 
 def write_kv_upload_file(partitions, name):


### PR DESCRIPTION
I noticed the lookup helper was calculating I noticed the lookup helper was calculating the partition key a bit differently from how partitions are actually created. In test_ip_lookup(), the mask was being applied to the shift amount, which can send some IPs to the wrong partition key. That means you can have a valid range in the data but still miss it during lookup. I changed the expression so it first shifts, then masks, same pattern used in create_kv_ip_partitions(). This keeps both sides consistent and avoids those annoying false negatives.